### PR TITLE
Add one more step to auth middleware to check user

### DIFF
--- a/backend/src/app/middlewares/auth.js
+++ b/backend/src/app/middlewares/auth.js
@@ -13,6 +13,8 @@ export default async (request, response, next) => {
 
   try {
     const decoded = await promisify(jwt.verify)(token, authConfig.secret);
+    
+    const user = await User.findByPk(decoded.id);
 
     if (user) {
       req.userId = decoded.id;

--- a/backend/src/app/middlewares/auth.js
+++ b/backend/src/app/middlewares/auth.js
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import { promisify } from 'util';
-
 import authConfig from '../../config/auth';
+import User from '../models/User';
 
 export default async (request, response, next) => {
   const authHeader = request.headers.authorization;
@@ -13,7 +13,13 @@ export default async (request, response, next) => {
 
   try {
     const decoded = await promisify(jwt.verify)(token, authConfig.secret);
-    request.userId = decoded.id;
+
+    if (user) {
+      req.userId = decoded.id;
+    } else {
+      throw new Error('Invalid token');
+    }
+
     return next();
   } catch (error) {
     return response.status(401).json({ error: 'Invalid token' });


### PR DESCRIPTION
Auth middleware just get the token, decode it and finally pass it to request param.

If user pass an invalid token that also has ID property, it will also pass to the request param and later your API will throw a error because the ID passed throught token is not valid.

I just added one more step that checks if ID passed throught token is valid.